### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,10 +1,10 @@
 Authors
 =======
 
-Flask-SSO is developed for use in `Invenio <http://invenio-software.org>`_
+Flask-SSO is developed for use in `Invenio <http://inveniosoftware.org>`_
 digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 Contributors
 ^^^^^^^^^^^^

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -31,8 +31,8 @@ Documentation
 Happy hacking and thanks for flying Flask-SSO.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/flask-sso
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-sso/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask-SSO extension that eases Shibboleth authentication.',
     long_description=open('README.rst').read(),
     packages=['flask_sso'],


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>